### PR TITLE
Add limit to GetResolutionForAspect() resolution

### DIFF
--- a/Scripts/SteamVR_Camera.cs
+++ b/Scripts/SteamVR_Camera.cs
@@ -67,11 +67,27 @@ public class SteamVR_Camera : MonoBehaviour
 
     public static Resolution GetResolutionForAspect(int aspectW, int aspectH)
         {
-            Resolution hmdResolution = GetSceneResolution();
+            return GetResolutionForAspect(aspectW, aspectH, GetSceneResolution());
+        }
 
+        public static Resolution GetResolutionForAspect(int aspectW, int aspectH, int maxWidth)
+        {
+            // Some games choke on very high resolutions.
+            // Resolution for aspect uses width and adjusts height to make it 16:9, so just clamp the width.
+            Resolution sceneRes = GetSceneResolution();
+            if (sceneRes.width >= maxWidth)
+            {
+                sceneRes.width = maxWidth;
+            }
+
+            return GetResolutionForAspect(aspectW, aspectH, sceneRes);
+        }
+
+        public static Resolution GetResolutionForAspect(int aspectW, int aspectH, Resolution hmdResolution)
+        {
             // We calcuate an optimal 16:9 resolution to use with the HMD resolution because that's the best aspect for the UI rendering
             Resolution closestToAspect = hmdResolution;
-            closestToAspect.height = closestToAspect.width / aspectW * aspectH;
+            closestToAspect.height = closestToAspect.width * aspectH / aspectW; // Divide last because decimals
             closestToAspect.width += closestToAspect.width % 2;
             closestToAspect.height += closestToAspect.height % 2;
             return closestToAspect;


### PR DESCRIPTION
## What
This PR adds an option to limit `GetResolutionForAspect()` to an upper width. 

This PR accompanied by a PR to the GTFO VR mod repo: https://github.com/DSprtn/GTFO_VR_Plugin/pull/48

## How

The `width` is used to calculate the corresponding `height` for that `aspect ratio`, so we basically just `clamp` the `width` of the input resolution.
This method is used to calculate the resolution of the GUI overlay, and GTFO will choke at very high resolutions ( e.g. `5718x3216` ), necessitating that we limit it.

One line of the formula was also modified so the division is performed last, as otherwise its decimal component is lost before the multiplication, resulting in a slightly incorrect result:
```csharp
closestToAspect.height = closestToAspect.width * aspectH / aspectW; // Divide last because decimals
````