### PR TITLE
Hidden Area Mask toggle, Visible Area Mask getter

### DIFF
--- a/Scripts/SteamVR_Render.cs
+++ b/Scripts/SteamVR_Render.cs
@@ -16,6 +16,9 @@ namespace Valve.VR
 : base(value) { }
 
 
+        public static readonly EVREye FirstEye = EVREye.Eye_Left;
+        public static readonly EVREye SecondEye = EVREye.Eye_Right;
+
         public static EVREye eye { get; private set; }
 
         public static float unfocusedRenderResolution = 1f;
@@ -181,13 +184,16 @@ namespace Valve.VR
 
                 RenderExternalCamera();
 
-                if(preRenderBothEyesCallback != null)
+                // Any common tasks should be part of the first eye, so set it early
+                SteamVR_Render.eye = FirstEye;
+
+                if (preRenderBothEyesCallback != null)
                 {
                     preRenderBothEyesCallback.Invoke();
                 }
                 var vr = SteamVR.instance;
-                RenderEye(vr, EVREye.Eye_Left);
-                RenderEye(vr, EVREye.Eye_Right);
+                RenderEye(vr, FirstEye);
+                RenderEye(vr, SecondEye);
 
                 // Move cameras back to head position so they can be tracked reliably
                 foreach (var c in cameras)

--- a/Scripts/SteamVR_Render.cs
+++ b/Scripts/SteamVR_Render.cs
@@ -23,6 +23,7 @@ namespace Valve.VR
 
         public static float unfocusedRenderResolution = 1f;
 
+        private static bool renderHiddenAreaMask = true;
 
 
         public static SteamVR_Render instance
@@ -569,6 +570,9 @@ namespace Valve.VR
             go.transform.parent = transform;
             cameraMask = go.AddComponent<SteamVR_CameraMask>();
 
+            // Value might have been set statically before Awake() was called
+            SetRenderHiddenAreaMask(renderHiddenAreaMask);
+
             if (externalCamera == null && System.IO.File.Exists(externalCameraConfigPath))
             {
                 var prefab = Resources.Load<GameObject>("SteamVR_ExternalCamera");
@@ -581,6 +585,14 @@ namespace Valve.VR
             }
         }
 
+        public static void SetRenderHiddenAreaMask(bool state)
+        {
+            renderHiddenAreaMask = state;
+            if ( instance != null )
+            {
+                instance.cameraMask.meshRenderer.enabled = renderHiddenAreaMask;
+            }
+        }
 
         public SteamVR_ExternalCamera externalCamera;
 


### PR DESCRIPTION
## What & How

This PR is required by https://github.com/DSprtn/GTFO_VR_Plugin/pull/55

### Eye order constants

Currently `SteamVR_Renderer` is hardcoded to render the left eye followed by the right eye. 
`SteamVR_Render.FirstEye` and `SteamVR_Render.SecondEye` have been defined and replace anywhere `EVREye.Eye_Left` or `EVREye.Eye_Right` were used directly. This allows the client game ( GTFO ) to easily check whether it is currently recording the first or second eye. 

### Hidden Area Mask toggle
Adds `SteamVR_VRRenderer.SetRenderHiddenAreaMask(bool enabled)` which sets `SteamVR_VRRenderer.cameraMask.meshRenderer.enabled`, enabling or disabling the hidden area mask mesh normally rendered just before the `gbuffer`.
In the case of GTFO all this does is fill the stencil with `0xC0`, resulting in this section being considered during the deferred final pass. This behavior is detrimental to the `Hidden Area Mask` that we manually draw in the `GTFO VR` plugin, so it needs to be able to disable it.
`SteamVR_VRRenderer.SetRenderHiddenAreaMask()` sets a static bool, and togglese the `MeshRenderer` only if it has been instantiated. SteamVR_VRRenderer.SetRenderHiddenAreaMask() is called with the current value in `SteamVR_VRRenderer.Awake()`, so the state can be set at any time, before or after instantiation.

### Visible Area Mask mesh getter
The new `SteamVR_CameraMask.getVisibleAreaMask(SteamVR, EVREye)` works pretty much the same as the existing `SteamVR_CameraMask.getHiddenAreaMask(SteamVR, EVREye)`, except it requests `EHiddenAreaMeshType.k_eHiddenAreaMesh_Inverse` instead of `EHiddenAreaMeshType.k_eHiddenAreaMesh_Standard`, and passes it to `SteamVR_CameraMask.CreateVisibleAreaMesh(HiddenAreaMesh_t, VRTextureBounds_t)` instead of `SteamVR_CameraMask.CreateHiddenAreaMesh(HiddenAreaMesh_t, VRTextureBounds_t)`to create a screen-space Unity `Mesh` out of it.
This Mesh is used in the `GTFO VR` plugin to render the `deferred final pass` onto, saving it the trouble of rendering anything to the non-visible areas.

The existing methods were refactored a bit to make everything cleaner, but remain functionally the same. 


![visible_area_mask](https://github.com/DSprtn/SteamVR_Standalone_IL2CPP/assets/8961771/c0451351-27e6-42b5-8464-41427ec133f0)
Pictured is the Visible Area Mask Mesh of the Queset 1. The rendered area outside of the mask is from the previous eye, as the same temporary `Render Texture` gets reused without being cleared.

